### PR TITLE
Feature/cax portal@cplp 404 assign client roles instead of groups at user creation

### DIFF
--- a/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -52,12 +52,11 @@ namespace CatenaX.NetworkServices.Registration.Service.BusinessLogic
                     Enabled = true
                 };
 
-                var userId = await client.CreateAndRetrieveUserIdAsync(realm, userToCreate);
+                var userId = await client.CreateAndRetrieveUserIdAsync(realm, userToCreate).ConfigureAwait(false);
                 var clientId = _configuration.GetValue<string>("KeyCloakClientID");
-                var roles = (await client.GetRolesAsync(realm, clientId))
-                    .Where(r => r.Name == user.Role);
+                var roles = new [] {await client.GetRoleByNameAsync(realm, clientId, user.Role).ConfigureAwait(false)};
 
-                await client.AddClientRoleMappingsToUserAsync(realm, userId, clientId, roles);
+                await client.AddClientRoleMappingsToUserAsync(realm, userId, clientId, roles).ConfigureAwait(false);
 
                 var inviteTemplateName = "invite";
                 if (!string.IsNullOrWhiteSpace(user.Message))
@@ -77,7 +76,7 @@ namespace CatenaX.NetworkServices.Registration.Service.BusinessLogic
                     
                 };
 
-                await _mailingService.SendMails(user.eMail, mailParameters, new List<string> { inviteTemplateName, "password" });
+                await _mailingService.SendMails(user.eMail, mailParameters, new List<string> { inviteTemplateName, "password" }).ConfigureAwait(false);
             }
         }
 

--- a/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -42,9 +42,9 @@ namespace CatenaX.NetworkServices.Registration.Service.BusinessLogic
         {
             var client = new KeycloakClient(_configuration.GetValue<string>("KeyCloakConnectionString"), () => token);
             var clientId = _configuration.GetValue<string>("KeyCloakClientID");
+            var pwd = new Password();
             foreach (UserCreationInfo user in userList)
             {
-                var pwd = new Password();
                 var password = pwd.Next();
                 var userToCreate = new User
                 {

--- a/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
+++ b/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/BusinessLogic/RegistrationBusinessLogic.cs
@@ -41,6 +41,7 @@ namespace CatenaX.NetworkServices.Registration.Service.BusinessLogic
         public async Task CreateUsersAsync(List<UserCreationInfo> userList, string realm, string token, Dictionary<string, string> userInfo)
         {
             var client = new KeycloakClient(_configuration.GetValue<string>("KeyCloakConnectionString"), () => token);
+            var clientId = _configuration.GetValue<string>("KeyCloakClientID");
             foreach (UserCreationInfo user in userList)
             {
                 var pwd = new Password();
@@ -53,7 +54,6 @@ namespace CatenaX.NetworkServices.Registration.Service.BusinessLogic
                 };
 
                 var userId = await client.CreateAndRetrieveUserIdAsync(realm, userToCreate).ConfigureAwait(false);
-                var clientId = _configuration.GetValue<string>("KeyCloakClientID");
                 var roles = new [] {await client.GetRoleByNameAsync(realm, clientId, user.Role).ConfigureAwait(false)};
 
                 await client.AddClientRoleMappingsToUserAsync(realm, userId, clientId, roles).ConfigureAwait(false);

--- a/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/appsettings.json
+++ b/coreservices/registration/src/CatenaX.NetworkServices.Registration.Service/appsettings.json
@@ -8,6 +8,7 @@
   },
   "AllowedHosts": "*",
   "KeyCloakConnectionString": "http://localhost:8080",
+  "KeyCloakClientID": "catenax-registration",
   "PostgresConnectionString": "http://localhost:8080",
   "BasePortalAddress": "https://test.azurewebsites.net",
   "CDQ_Address": "",


### PR DESCRIPTION
CPLP-404:
assign client roles instead of groups at user creation
added keycloak clientID as configurable value