### PR TITLE
Feature/cax portal@cplp 380 client roles from token

### DIFF
--- a/portal/code/company-portal/src/components/cax-header.tsx
+++ b/portal/code/company-portal/src/components/cax-header.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 import i18n from '../i18n';
 import { Row, Col } from 'react-bootstrap';
 import UserService from '../helpers/UserService';
-import { getUserClientRolesComposite } from '../helpers/utils';
+import { getClientRolesComposite } from '../helpers/utils';
 import { useState, useEffect } from "react";
 import { withRouter } from "react-router-dom";
 import { useTranslation } from 'react-i18next';
@@ -28,14 +28,16 @@ export const Header = () => {
 
     const username =  UserService.getUsername();
     const initials =  UserService.getInitials();
+    const tokenRoles =  UserService.getRoles();
     const [userRoles, setuserRoles] =  useState([]);
     const [language, setlanguage] =  useState(i18n.language);
 
     useEffect(() => {
         // declare the data fetching function
         const fetchData = async () => {
-          const data = await getUserClientRolesComposite();
-          setuserRoles(data);
+          const data = await getClientRolesComposite();
+          const filterComposite = tokenRoles.filter((value: string) => data.includes(value));
+          setuserRoles(filterComposite);
         }
       
         // call the function

--- a/portal/code/company-portal/src/helpers/UserService.js
+++ b/portal/code/company-portal/src/helpers/UserService.js
@@ -21,6 +21,8 @@ if (!clientId || clientId == 'null') {
 }
 localStorage.setItem('clientId', clientId);
 
+const CX_CLIENT = 'catenax-registration';
+
 const _kc = new Keycloak({
   "url": process.env.REACT_APP_KEYCLOAK_URL,
   "realm": realm,
@@ -75,6 +77,7 @@ const getInitials = () => _kc.tokenParsed?.preferred_username.split(/[.@]/).redu
 
 const getDomain = () => realm;//_kc.tokenParsed?.split('/').pop();
 
+const getRoles = () => _kc.tokenParsed?.resource_access[CX_CLIENT]?.roles;
 
 const hasRole = (roles) => roles.some((role) => _kc.hasRealmRole(role));
 
@@ -92,7 +95,8 @@ const UserService = {
   hasRole,
   realm,
   clientId,
-  getTenant
+  getTenant,
+  getRoles
 };
 
 export default UserService;

--- a/portal/code/company-portal/src/helpers/utils.ts
+++ b/portal/code/company-portal/src/helpers/utils.ts
@@ -134,32 +134,6 @@ export function getUserRoles(): Promise<UserRole[]> {
   return promise;
 }
 
-// to be removed with CPLP-380
-export function getUserClientRolesComposite(): Promise<string[]> {
-  const realm = UserService.realm;
-  const clientId = UserService.clientId;
-  const token = UserService.getToken();
-  const u= `${url}/${endpoint}/${realm}/clients/${clientId}/userRoleMappingsComposite`;
-  let userRolesRes: string[] = [];
-  const promise = new Promise<string[]>((resolve, reject) => {
-    fetch(u, { method: 'GET', headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' } })
-    .then((val) => val.json().then((data) => {
-      if (val.ok) {
-        Object.assign(userRolesRes,data)
-        resolve(userRolesRes);
-      } else {
-        reject(val.statusText);
-      }
-    })).catch((error) => {
-        alert(error);
-        console.log(error, error.message, error.status);
-        reject(error.message);
-      });
-  });
-
-  return promise;
-}
-
 export function getClientRolesComposite(): Promise<string[]> {
   const token = UserService.getToken();
   const u= `${url}/${endpoint}/rolesComposite`;


### PR DESCRIPTION
Addresses https://jira.catena-x.net/browse/CPLP-380 Registration Service - Get composite roles from user token and will also solve https://jira.catena-x.net/browse/CPLP-566 Registration App - User Role not correctly fetched.
- added filtering of composite client roles from user token
- removed obsolete integration of userRoleMappingsComposite endpoint