### PR TITLE
CPLP-595: fixed passing of message to backend at user invite

### DIFF
--- a/portal/code/company-portal/src/components/cax-responsibilities.tsx
+++ b/portal/code/company-portal/src/components/cax-responsibilities.tsx
@@ -53,7 +53,7 @@ export const ResponsibilitiesCax = ({
   const { t } = useTranslation();
   const [email, setEmail] = useState<string | null>("");
   const [role, setRole] = useState<string | null>("");
-  const [personalNote, setPersonalNote] = useState<string | null>("");
+  const [message, setMessage] = useState<string | null>("");
   const [availableUserRoles, setavailableUserRoles] = useState([]);
   const [error, setError] = useState<{ email: string; role: string }>({
     email: "",
@@ -90,12 +90,12 @@ export const ResponsibilitiesCax = ({
         uiId: uuidv4(),
         email: email,
         role: role,
-        personalNote: personalNote,
+        message: message,
       };
 
       addToInviteList(data);
       setEmail("");
-      setPersonalNote("");
+      setMessage("");
       if (availableUserRoles && availableUserRoles.length > 0)
         setRole(availableUserRoles[0]);
     }
@@ -231,8 +231,8 @@ export const ResponsibilitiesCax = ({
               <label> Personal note</label>
               <textarea
                 name="message"
-                value={personalNote}
-                onChange={(e) => setPersonalNote(e.target.value)}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
               />
               <div className="company-hint">
                 Optional message in the invitation e-mail. Lorem Ipsum

--- a/portal/code/company-portal/src/types/user/user.types.ts
+++ b/portal/code/company-portal/src/types/user/user.types.ts
@@ -4,7 +4,7 @@ export interface IUserItem {
     uiId: string;
     email: string;
     role: string;
-    personalNote: string;
+    message: string;
 }
 
 


### PR DESCRIPTION
https://jira.catena-x.net/browse/CPLP-595: Registration App - User invite: Message (renamed to Personal note) isn't passed to backend
Cause: at the renaming of the field 'Message' to 'Personal note' it apparently wasn't considered that the field is still called 'message' not 'personalNote' in the backend.