### PR TITLE
CPLP-497: new db-based user-query service

### DIFF
--- a/coreservices/CatenaX.NetworkServices.sln
+++ b/coreservices/CatenaX.NetworkServices.sln
@@ -63,6 +63,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatenaX.NetworkServices.Pro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatenaX.NetworkServices.Provisioning.Service", "provisioning\src\CatenaX.NetworkServices.Provisioning.Service\CatenaX.NetworkServices.Provisioning.Service.csproj", "{AFB6DF80-7E9B-4E85-82DF-74686C904ABE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatenaX.NetworkServices.Keycloak.DBAccess", "keycloak\src\CatenaX.NetworkServices.Keycloak.DBAccess\CatenaX.NetworkServices.Keycloak.DBAccess.csproj", "{345AB1AF-8E2E-4669-B468-4F191554E340}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,10 @@ Global
 		{AFB6DF80-7E9B-4E85-82DF-74686C904ABE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFB6DF80-7E9B-4E85-82DF-74686C904ABE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AFB6DF80-7E9B-4E85-82DF-74686C904ABE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{345AB1AF-8E2E-4669-B468-4F191554E340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{345AB1AF-8E2E-4669-B468-4F191554E340}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{345AB1AF-8E2E-4669-B468-4F191554E340}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{345AB1AF-8E2E-4669-B468-4F191554E340}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +184,7 @@ Global
 		{FE4A5E1E-2CB8-4149-9D22-C8C8D7FF5708} = {361B4010-82C0-11EC-8131-8BF7616386B6}
 		{655B039F-508A-430D-A942-960DDFED465B} = {41E2D910-2D1D-11EC-A4AF-635467519A0C}
 		{AFB6DF80-7E9B-4E85-82DF-74686C904ABE} = {41E2D910-2D1D-11EC-A4AF-635467519A0C}
+		{345AB1AF-8E2E-4669-B468-4F191554E340} = {361B4010-82C0-11EC-8131-8BF7616386B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {23E9EF5A-FB26-4AAC-952E-0695A1245B8E}

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/BusinessLogic/IUserAdministrationBusinessLogic.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/BusinessLogic/IUserAdministrationBusinessLogic.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CatenaX.NetworkServices.Invitation.Service.Models;
+
+namespace CatenaX.NetworkServices.Invitation.Service.BusinessLogic
+
+{
+    public interface IUserAdministrationBusinessLogic
+    {
+        Task<IEnumerable<JoinedUserInfo>> GetJoinedUserInfosAsync(string tenant,
+                                                                  string userId = null,
+                                                                  string providerUserId = null,
+                                                                  string userName = null,
+                                                                  string firstName = null,
+                                                                  string lastName = null,
+                                                                  string email = null);
+    }
+}

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/BusinessLogic/UserAdministrationBusinessLogic.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/BusinessLogic/UserAdministrationBusinessLogic.cs
@@ -1,0 +1,43 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CatenaX.NetworkServices.Invitation.Service.Models;
+using CatenaX.NetworkServices.Keycloak.DBAccess;
+
+namespace CatenaX.NetworkServices.Invitation.Service.BusinessLogic
+
+{
+    public class UserAdministrationBusinessLogic : IUserAdministrationBusinessLogic
+    {
+        private readonly IKeycloakDBAccess _KeycloakDBAccess;
+
+        public UserAdministrationBusinessLogic(IKeycloakDBAccess keycloakDBAccess)
+        {
+            _KeycloakDBAccess = keycloakDBAccess;
+        }
+
+        public async Task<IEnumerable<JoinedUserInfo>> GetJoinedUserInfosAsync(string tenant,
+                                                                               string userId = null,
+                                                                               string providerUserId = null,
+                                                                               string userName = null,
+                                                                               string firstName = null,
+                                                                               string lastName = null,
+                                                                               string email = null) =>
+            (await _KeycloakDBAccess.GetUserJoinedFederatedIdentity(tenant,
+                                                                    userId,
+                                                                    providerUserId,
+                                                                    userName,
+                                                                    firstName,
+                                                                    lastName,
+                                                                    email).ConfigureAwait(false))
+                .Select( r => new JoinedUserInfo {
+                    userId = r.id,
+                    providerUserId = r.federated_user_id,
+                    userName = r.federated_username,
+                    firstName = r.first_name,
+                    lastName = r.last_name,
+                    email = r.email
+                });
+    }
+}

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/CatenaX.NetworkServices.Invitation.Service.csproj
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/CatenaX.NetworkServices.Invitation.Service.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\..\mailing\src\CatenaX.NetworkServices.Mailing.Template\CatenaX.NetworkServices.Mailing.Template.csproj" />
     <ProjectReference Include="..\..\..\keycloak\src\CatenaX.NetworkServices.Keycloak.Authentication\CatenaX.NetworkServices.Keycloak.Authentication.csproj" />
     <ProjectReference Include="..\..\..\provisioning\src\CatenaX.NetworkServices.Provisioning.Library\CatenaX.NetworkServices.Provisioning.Library.csproj" />
+    <ProjectReference Include="..\..\..\keycloak\src\CatenaX.NetworkServices.Keycloak.DBAccess\CatenaX.NetworkServices.Keycloak.DBAccess.csproj" />
   </ItemGroup>
 
 </Project>

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Controllers/UserAdministrationController.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Controllers/UserAdministrationController.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using CatenaX.NetworkServices.Invitation.Service.BusinessLogic;
+using System.Collections.Generic;
+using CatenaX.NetworkServices.Invitation.Service.Models;
+
+namespace CatenaX.NetworkServices.Invitation.Service.Controllers
+{
+    [ApiController]
+    public class UserAdministrationController : ControllerBase
+    {
+
+        private readonly ILogger<UserAdministrationController> _logger;
+        private readonly IUserAdministrationBusinessLogic _logic;
+
+        public UserAdministrationController(ILogger<UserAdministrationController> logger, IUserAdministrationBusinessLogic logic)
+        {
+            _logger = logger;
+            _logic = logic;
+        }
+
+        [HttpGet]
+        [Route("api/invitation/tenant/{tenant}/joinedusers")]
+        public Task<IEnumerable<JoinedUserInfo>> QueryJoinedUsers(
+                [FromRoute] string tenant,
+                [FromQuery] string userId = null,
+                [FromQuery] string providerUserId = null,
+                [FromQuery] string userName = null,
+                [FromQuery] string firstName = null,
+                [FromQuery] string lastName = null,
+                [FromQuery] string email = null) =>
+            _logic.GetJoinedUserInfosAsync(tenant, userId, providerUserId, userName, firstName, lastName, email);
+    }
+}

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Controllers/UserAdministrationController.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Controllers/UserAdministrationController.cs
@@ -26,6 +26,7 @@ namespace CatenaX.NetworkServices.Invitation.Service.Controllers
         }
 
         [HttpGet]
+        [Authorize(Roles="view_user_management")]
         [Route("api/invitation/tenant/{tenant}/joinedusers")]
         public Task<IEnumerable<JoinedUserInfo>> QueryJoinedUsers(
                 [FromRoute] string tenant,

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Models/JoinedUserInfo.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Models/JoinedUserInfo.cs
@@ -1,0 +1,14 @@
+
+namespace CatenaX.NetworkServices.Invitation.Service.Models
+
+{
+    public class JoinedUserInfo
+    {
+        public string userId { get; set; }
+        public string providerUserId { get; set; }
+        public string userName { get; set; }
+        public string firstName { get; set; }
+        public string lastName { get; set; }
+        public string email { get; set; }
+    }
+}

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Startup.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Startup.cs
@@ -60,7 +60,7 @@ namespace CatenaX.NetworkServices.Invitation.Service
                     .ConfigureInvitationSettings(Configuration.GetSection("Invitation"));
 
             services.AddTransient<IKeycloakDBAccess, KeycloakDBAccess>()
-                    .AddTransient<IDbConnection>(conn => new NpgsqlConnection(Configuration.GetValue<string>("CentralIdpPostgresConnectionString")));
+                    .AddTransient<IDbConnection>(conn => new NpgsqlConnection(Configuration.GetValue<string>("CentralIdpDatabaseConnectionString")));
 
             services.AddTransient<IUserAdministrationBusinessLogic, UserAdministrationBusinessLogic>();
         }

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Startup.cs
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/Startup.cs
@@ -7,14 +7,17 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using CatenaX.NetworkServices.Keycloak.Authentication;
+using CatenaX.NetworkServices.Keycloak.DBAccess;
 using CatenaX.NetworkServices.Keycloak.Factory;
 using CatenaX.NetworkServices.Mailing.SendMail;
 using CatenaX.NetworkServices.Mailing.Template;
 using CatenaX.NetworkServices.Provisioning.Library;
 using CatenaX.NetworkServices.Invitation.Service.BusinessLogic;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using System.IdentityModel.Tokens.Jwt;
+
+using Npgsql;
+
+using System.Data;
 
 namespace CatenaX.NetworkServices.Invitation.Service
 {
@@ -55,6 +58,11 @@ namespace CatenaX.NetworkServices.Invitation.Service
             
             services.AddTransient<IInvitationBusinessLogic, InvitationBusinessLogic>()
                     .ConfigureInvitationSettings(Configuration.GetSection("Invitation"));
+
+            services.AddTransient<IKeycloakDBAccess, KeycloakDBAccess>()
+                    .AddTransient<IDbConnection>(conn => new NpgsqlConnection(Configuration.GetValue<string>("CentralIdpPostgresConnectionString")));
+
+            services.AddTransient<IUserAdministrationBusinessLogic, UserAdministrationBusinessLogic>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/appsettings.json
+++ b/coreservices/invitation/src/CatenaX.NetworkServices.Invitation.Service/appsettings.json
@@ -7,6 +7,7 @@
     }
   },
   "SwaggerEnabled": "",
+  "CentralIdpDatabaseConnectionString": "",
   "Keycloak": {
     "central": {
       "ConnectionString": "",

--- a/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/CatenaX.NetworkServices.Keycloak.DBAccess.csproj
+++ b/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/CatenaX.NetworkServices.Keycloak.DBAccess.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/IKeycloakDBAccess.cs
+++ b/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/IKeycloakDBAccess.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CatenaX.NetworkServices.Keycloak.DBAccess.Model;
+
+namespace CatenaX.NetworkServices.Keycloak.DBAccess
+
+{
+    public interface IKeycloakDBAccess
+    {
+        Task<IEnumerable<UserJoinedFederatedIdentity>> GetUserJoinedFederatedIdentity(string idpName,
+                                                                                      string userId = null,
+                                                                                      string providerUserId = null,
+                                                                                      string userName = null,
+                                                                                      string firstName = null,
+                                                                                      string lastName = null,
+                                                                                      string email = null);
+    }
+}

--- a/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/KeycloakDBAccess.cs
+++ b/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/KeycloakDBAccess.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+
+using Dapper;
+
+using CatenaX.NetworkServices.Keycloak.DBAccess.Model;
+
+namespace CatenaX.NetworkServices.Keycloak.DBAccess
+
+{
+    public class KeycloakDBAccess : IKeycloakDBAccess
+    {
+        private readonly IDbConnection _dbConnection;
+
+        public KeycloakDBAccess(IDbConnection dbConnection)
+        {
+            _dbConnection = dbConnection;
+        }
+
+        public async Task<IEnumerable<UserJoinedFederatedIdentity>> GetUserJoinedFederatedIdentity(string idpName,
+                                                                                                   string userId = null,
+                                                                                                   string providerUserId = null,
+                                                                                                   string userName = null,
+                                                                                                   string firstName = null,
+                                                                                                   string lastName = null,
+                                                                                                   string email = null)
+        {
+            string sql =
+                "SELECT" +
+                " id," +
+                " email," +
+                " first_name," +
+                " last_name," +
+                " federated_user_id," +
+                " federated_username" +
+                " FROM public.user_entity c" +
+                " JOIN public.federated_identity f" +
+                " ON c.realm_id = f.realm_id" +
+                " AND c.id = f.user_id" +
+                " WHERE f.identity_provider = @idpName" +
+                (userId         == null ? "" : " AND c.id = @userId") +
+                (providerUserId == null ? "" : " AND f.federated_user_id = @providerUserId") +
+                (userName       == null ? "" : " AND f.federated_username = @userName") +
+                (firstName      == null ? "" : " AND c.first_name = @firstName") +
+                (lastName       == null ? "" : " AND c.last_name = @lastName") + 
+                (email          == null ? "" : " AND c.email = @email");
+            using (_dbConnection)
+            {
+                return await _dbConnection.QueryAsync<UserJoinedFederatedIdentity>(sql, new { idpName        = idpName,
+                                                                                              userId         = userId,
+                                                                                              providerUserId = providerUserId,
+                                                                                              userName       = userName,
+                                                                                              firstName      = firstName,
+                                                                                              lastName       = lastName,
+                                                                                              email          = email });
+            }
+        }
+    }
+}

--- a/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/Model/UserJoindedFederatedIdentity.cs
+++ b/coreservices/keycloak/src/CatenaX.NetworkServices.Keycloak.DBAccess/Model/UserJoindedFederatedIdentity.cs
@@ -1,0 +1,13 @@
+namespace CatenaX.NetworkServices.Keycloak.DBAccess.Model
+
+{
+    public class UserJoinedFederatedIdentity
+    {
+        public string id { get; set; } 
+        public string email { get; set; }
+        public string first_name { get; set; }
+        public string last_name { get; set; }
+        public string federated_user_id { get; set; }
+        public string federated_username { get; set; }
+    }
+}


### PR DESCRIPTION
as discussed to unify shared-idp and own-idp user administration we need a db-based query facility.
Here it is.
It allows to query the central idp for users of a specific tenant. (Optional) selection-criteria are userid, providerUserId, userName, firstName, lastName and email.
With the result we can directly target the ids in central and shared idps for any scenario that requires a userlookup first.
The intention is to replace the existing endpont 'GET /api/invitation/tenant/{tenant}/users' (as of now I did preliminary chose a different - non-conflicting - path, we should change that before merging)
(So far it is not secured yet).