### PR TITLE
CPLP-497: route adjustments for useradministation endpoint (also invitation) to match ingress & removed Sonar from portal pipeline

### DIFF
--- a/.github/workflows/portal.yml
+++ b/.github/workflows/portal.yml
@@ -113,23 +113,7 @@ jobs:
             echo "Unsupported Environment/Repository. Leaving Workspace empty."
           fi
   ##########################################
-  # Second job does the Sonar scan
-  ##########################################
-  sonarcloud:
-    name: SonarCloud
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          
-  ##########################################
-  # Third job does the real container work
+  # Second job does the real container work
   ##########################################
   # FROM HERE ON: NO ADAPTION NEEDED ANYMORE
 
@@ -215,7 +199,7 @@ jobs:
          echo "REACT_APP_BROKER_ENDPOINT=https://${{env.CATENA_SERVICE_URL}}/connectorprovider" >>.env
          echo "REACT_APP_CONNECTOR_ENDPOINT=https://${{env.CATENA_SERVICE_URL}}/connectorconsumer" >>.env
          echo "REACT_APP_KEYCLOAK_URL=https://${{env.CATENA_SERVICE_URL}}/iamcentralidp/auth" >> .env
-         echo "REACT_APP_INVITE_ENDPOINT=https://${{env.CATENA_SERVICE_URL}}/api/invitation" >>.env
+         echo "REACT_APP_INVITE_ENDPOINT=https://${{env.CATENA_SERVICE_URL}}/api/useradministration/invitation" >>.env
          echo -n "REACT_APP_CONNECTOR_AUTHENTICATION=" >>.env 
          echo -n "${{secrets.CATENAX_ADMIN_USER}}:${{secrets.CATENAX_ADMIN_PASSWORD}}" | base64 >> .env
          echo "" >>.env

--- a/coreservices/useradministration/src/CatenaX.NetworkServices.UserAdministration.Service/Controllers/UserAdministrationController.cs
+++ b/coreservices/useradministration/src/CatenaX.NetworkServices.UserAdministration.Service/Controllers/UserAdministrationController.cs
@@ -15,6 +15,7 @@ using CatenaX.NetworkServices.Provisioning.Library.Models;
 namespace CatenaX.NetworkServices.UserAdministration.Service.Controllers
 {
     [ApiController]
+    [Route("api/useradministration")]
     public class UserAdministrationController : ControllerBase
     {
 
@@ -29,7 +30,7 @@ namespace CatenaX.NetworkServices.UserAdministration.Service.Controllers
 
         [HttpPost]
         [Authorize(Roles="invite_new_partner")]
-        [Route("api/invitation")]
+        [Route("invitation")]
         public async Task<IActionResult> ExecuteInvitation([FromBody] InvitationData InvitationData)
         {
             try
@@ -50,7 +51,7 @@ namespace CatenaX.NetworkServices.UserAdministration.Service.Controllers
 
         [HttpPost]
         [Authorize(Roles="add_user_account")]
-        [Route("api/administration/tenant/{tenant}/users")]
+        [Route("tenant/{tenant}/users")]
         public async Task<IActionResult> ExecuteUserCreation([FromRoute] string tenant, [FromBody] IEnumerable<UserCreationInfo> usersToCreate)
         {
             try
@@ -71,7 +72,7 @@ namespace CatenaX.NetworkServices.UserAdministration.Service.Controllers
 
         [HttpGet]
         [Authorize(Roles="view_user_management")]
-        [Route("api/administration/tenant/{tenant}/users")]
+        [Route("tenant/{tenant}/users")]
         public Task<IEnumerable<JoinedUserInfo>> QueryJoinedUsers(
                 [FromRoute] string tenant,
                 [FromQuery] string userId = null,
@@ -84,12 +85,12 @@ namespace CatenaX.NetworkServices.UserAdministration.Service.Controllers
 
         [HttpGet]
         [Authorize(Roles="view_client_roles")]
-        [Route("api/administration/client/{clientId}/roles")]
+        [Route("client/{clientId}/roles")]
         public Task<IEnumerable<string>> ReturnRoles([FromRoute] string clientId) =>
             _logic.GetAppRolesAsync(clientId);
 
         [HttpDelete]
-        [Route("api/administration/tenant/{tenant}/ownUser")]
+        [Route("tenant/{tenant}/ownUser")]
         public async Task<IActionResult> ExecuteOwnUserDeletion([FromRoute] string tenant)
         {
             try
@@ -111,7 +112,7 @@ namespace CatenaX.NetworkServices.UserAdministration.Service.Controllers
 
         [HttpDelete]
         [Authorize(Roles="delete_user_account")]
-        [Route("api/administration/tenant/{tenant}/users")]
+        [Route("tenant/{tenant}/users")]
         public async Task<IActionResult> ExecuteUserDeletion([FromRoute] string tenant, [FromBody] UserDeletionInfo usersToDelete)
         {
             try

--- a/portal/code/tractus-x-portal/.env
+++ b/portal/code/tractus-x-portal/.env
@@ -11,6 +11,6 @@ REACT_APP_BROKER_ENDPOINT=https://catenaxintakssrv.germanywestcentral.cloudapp.a
 REACT_APP_CONNECTOR_ENDPOINT=https://catenaxintakssrv.germanywestcentral.cloudapp.azure.com/connectorconsumer
 REACT_APP_CONNECTOR_AUTHENTICATION=Q2F0ZW5hWDpYYXRlbmFDNDI=
 REACT_APP_KEYCLOAK_URL=https://catenaxdev003akssrv.germanywestcentral.cloudapp.azure.com/iamcentralidp/auth
-REACT_APP_INVITE_ENDPOINT=https://catenaxdev003akssrv.germanywestcentral.cloudapp.azure.com/api/invitation
+REACT_APP_INVITE_ENDPOINT=https://catenaxdev003akssrv.germanywestcentral.cloudapp.azure.com/api/useradministration/invitation
 # Needs to be true to avoid version conflict of component library project's babel-jest package
 SKIP_PREFLIGHT_CHECK=true


### PR DESCRIPTION
https://jira.catena-x.net/browse/CPLP-497: changed routes of useradministration endpoints (also invitation) to match ingress
https://jira.catena-x.net/browse/CPLP-158: also removed sonar from portal workflow file as sonar secret is missing in fork and blocks pipeline