### PR TITLE
CPLP-632: Optionally pass a link component to user nav

### DIFF
--- a/portal/code/cx-portal-shared-components/src/components/content/UserMenu/UserMenu.stories.tsx
+++ b/portal/code/cx-portal-shared-components/src/components/content/UserMenu/UserMenu.stories.tsx
@@ -13,12 +13,12 @@ const Template: ComponentStory<typeof Component> = (args: any) => (
   <Component {...args}>
     <UserNav
       items={[
-        { link: '/account', title: 'My Account' },
-        { link: '/notification', title: 'Notification Center' },
-        { link: '/organisation', title: 'Organisation' },
+        { href: '/account', title: 'My Account' },
+        { href: '/notification', title: 'Notification Center' },
+        { href: '/organisation', title: 'Organisation' },
       ]}
     />
-    <UserNav items={[{ link: '/logout', title: 'Logout' }]} />
+    <UserNav items={[{ href: '/logout', title: 'Logout' }]} />
     <LanguageSwitch
       current="de"
       languages={[{ key: 'de' }, { key: 'en' }]}

--- a/portal/code/cx-portal-shared-components/src/components/content/UserNav/UserNav.stories.tsx
+++ b/portal/code/cx-portal-shared-components/src/components/content/UserNav/UserNav.stories.tsx
@@ -14,9 +14,9 @@ const Template: ComponentStory<typeof Component> = (args: any) => (
 export const UserNav = Template.bind({})
 UserNav.args = {
   items: [
-    { link: '/account', title: 'My Account' },
-    { link: '/notification', title: 'Notification Center' },
-    { link: '/organisation', title: 'Organisation' },
-    { link: '/logout', title: 'Logout' },
+    { href: '/account', title: 'My Account' },
+    { href: '/notification', title: 'Notification Center' },
+    { href: '/organisation', title: 'Organisation' },
+    { href: '/logout', title: 'Logout' },
   ],
 }

--- a/portal/code/cx-portal-shared-components/src/components/content/UserNav/index.tsx
+++ b/portal/code/cx-portal-shared-components/src/components/content/UserNav/index.tsx
@@ -1,31 +1,34 @@
 import { Divider, Link, List, ListItem, useTheme } from '@mui/material'
+import uniqueId from 'lodash/uniqueId'
 
-interface UserNavItem {
-  link: string
+type LinkItem = Partial<Record<'href' | 'to', string>>
+
+interface UserNavItem extends LinkItem {
   title: string
   divider?: boolean
 }
 
 interface UserNavProps {
   items: UserNavItem[]
+  component?: React.ElementType
 }
 
-export const UserNav = ({ items }: UserNavProps) => {
+export const UserNav = ({ items, component = Link }: UserNavProps) => {
   const { spacing } = useTheme()
 
   return (
     <>
       <List sx={{ padding: spacing(0, 1) }}>
-        {items?.map(({ link, title, divider }) => (
+        {items?.map(({ title, divider, ...link }) => (
           <ListItem
-            key={link}
+            key={uniqueId('UserNav')}
             sx={{
               display: 'block',
               padding: 0,
             }}
           >
             <Link
-              href={link}
+              component={component}
               sx={{
                 color: 'text.primary',
                 display: 'block',
@@ -37,6 +40,7 @@ export const UserNav = ({ items }: UserNavProps) => {
                   color: 'primary.dark',
                 },
               }}
+              {...link}
             >
               {title}
             </Link>

--- a/portal/code/cx-portal/src/components/shared/frame/UserInfo/UserInfo.tsx
+++ b/portal/code/cx-portal/src/components/shared/frame/UserInfo/UserInfo.tsx
@@ -10,6 +10,7 @@ import i18next, { changeLanguage } from 'i18next'
 import I18nService from 'services/I18nService'
 import AccessService from 'services/AccessService'
 import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import './UserInfo.scss'
 
 export const UserInfo = () => {
@@ -37,8 +38,9 @@ export const UserInfo = () => {
         onClickAway={onClickAway}
       >
         <UserNav
+          component={Link}
           items={AccessService.userMenu().map((link) => ({
-            link,
+            to: link,
             title: t(`pages.${link}`),
           }))}
         />


### PR DESCRIPTION
adds the possibility to pass a link component (e.g. Link from react-router) to user nav.
fixes the issue that the links are reloading the full page.